### PR TITLE
Update helm charts to handle rockcraft and a different storage.path

### DIFF
--- a/deploy/charts/rawfile-csi/templates/00-driver.yaml
+++ b/deploy/charts/rawfile-csi/templates/00-driver.yaml
@@ -6,6 +6,6 @@ spec:
   attachRequired: false
   podInfoOnMount: true
   fsGroupPolicy: File
-  storageCapacity: true
+  storageCapacity: false  # TODO: reenable once switch from using v1beta1 apis
   volumeLifecycleModes:
     - Persistent

--- a/deploy/charts/rawfile-csi/templates/01-controller-plugin.yaml
+++ b/deploy/charts/rawfile-csi/templates/01-controller-plugin.yaml
@@ -42,6 +42,10 @@ spec:
           image: "{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}"
           imagePullPolicy: {{ .Values.controller.image.pullPolicy }}
           args:
+          {{- if regexMatch "\\/canonical\\/" .Values.controller.image.repository }}
+            - --args
+            - rawfile
+          {{- end }}
             - csi-driver
             - --disable-metrics
           env:

--- a/deploy/charts/rawfile-csi/templates/01-controller-plugin.yaml
+++ b/deploy/charts/rawfile-csi/templates/01-controller-plugin.yaml
@@ -42,12 +42,9 @@ spec:
           image: "{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}"
           imagePullPolicy: {{ .Values.controller.image.pullPolicy }}
           args:
-          {{- if regexMatch "\\/canonical\\/" .Values.controller.image.repository }}
-            - --args
-            - rawfile
-          {{- end }}
-            - csi-driver
-            - --disable-metrics
+            {{ range .Values.controller.csi_driver_args }}
+            - {{ . }}
+            {{ end }}
           env:
             - name: PROVISIONER_NAME
               value: "{{ .Values.provisionerName }}"

--- a/deploy/charts/rawfile-csi/templates/01-controller-plugin.yaml
+++ b/deploy/charts/rawfile-csi/templates/01-controller-plugin.yaml
@@ -34,6 +34,10 @@ spec:
           operator: Equal
           value: "true"
           effect: NoSchedule
+        - key: "node-role.kubernetes.io/control-plane"
+          operator: Equal
+          value: "true"
+          effect: NoSchedule
       volumes:
         - name: socket-dir
           emptyDir: {}
@@ -41,10 +45,10 @@ spec:
         - name: csi-driver
           image: "{{ .Values.controller.image.repository }}:{{ .Values.controller.image.tag }}"
           imagePullPolicy: {{ .Values.controller.image.pullPolicy }}
+          {{- if .Values.controller.csiDriverArgs }}
           args:
-            {{ range .Values.controller.csi_driver_args }}
-            - {{ . }}
-            {{ end }}
+          {{- .Values.controller.csiDriverArgs | toYaml | nindent 10 }}
+          {{- end }}
           env:
             - name: PROVISIONER_NAME
               value: "{{ .Values.provisionerName }}"

--- a/deploy/charts/rawfile-csi/templates/01-node-plugin.yaml
+++ b/deploy/charts/rawfile-csi/templates/01-node-plugin.yaml
@@ -51,7 +51,7 @@ spec:
             type: DirectoryOrCreate
         - name: data-dir
           hostPath:
-            path: "{{ .Values.node.storage.path }}"
+            path: {{ .Values.node.storage.path | quote }}
             type: DirectoryOrCreate
       containers:
         - name: csi-driver

--- a/deploy/charts/rawfile-csi/templates/01-node-plugin.yaml
+++ b/deploy/charts/rawfile-csi/templates/01-node-plugin.yaml
@@ -51,7 +51,7 @@ spec:
             type: DirectoryOrCreate
         - name: data-dir
           hostPath:
-            path: /var/csi/rawfile
+            path: "{{ .Values.node.storage.path }}"
             type: DirectoryOrCreate
       containers:
         - name: csi-driver

--- a/deploy/charts/rawfile-csi/values.yaml
+++ b/deploy/charts/rawfile-csi/values.yaml
@@ -15,6 +15,9 @@ defaults: &defaults
 
 controller:
   <<: *defaults
+  csi_driver_args:
+    - csi-driver
+    - --disable-metrics
 
 node:
   <<: *defaults

--- a/deploy/charts/rawfile-csi/values.yaml
+++ b/deploy/charts/rawfile-csi/values.yaml
@@ -18,6 +18,8 @@ controller:
 
 node:
   <<: *defaults
+  storage:
+    path: /var/csi/rawfile
   metrics:
     enabled: false
 

--- a/deploy/charts/rawfile-csi/values.yaml
+++ b/deploy/charts/rawfile-csi/values.yaml
@@ -15,7 +15,7 @@ defaults: &defaults
 
 controller:
   <<: *defaults
-  csi_driver_args:
+  csiDriverArgs:
     - csi-driver
     - --disable-metrics
 


### PR DESCRIPTION
Parameterize the storage path location, and if the image is the canonical rockcraft based image, launch with pebble arguments


Installation of the rockcraft image:
---
```bash
sudo k8s helm install -n kube-system \
    --set controller.image.repository=ghcr.io/canonical/rawfile-localpv \
    --set node.image.repository=ghcr.io/canonical/rawfile-localpv \
    --set node.storage.path=/var/snap/k8s/common/local-storage \
    --set serviceMonitor.enabled=false \
    --set node.image.tag=0.8.0-ck1 \
    --set controller.image.tag=0.8.0-ck1 \
    --set controller.csiDriverArgs='{--args,rawfile,csi-driver,--disable-metrics}' \
    rawfile-csi ./deploy/charts/rawfile-csi/
```
