### PR TITLE
Create default storage class in chart

### DIFF
--- a/deploy/charts/rawfile-csi/templates/02-storageclass.yaml
+++ b/deploy/charts/rawfile-csi/templates/02-storageclass.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.storageClass.enabled }}
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: {{ .Values.storageClass.name }}
+  annotations:
+    storageclass.kubernetes.io/is-default-class: {{ .Values.storageClass.isDefault }}
+provisioner: rawfile.csi.openebs.io
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+{{- end }}

--- a/deploy/charts/rawfile-csi/templates/02-storageclass.yaml
+++ b/deploy/charts/rawfile-csi/templates/02-storageclass.yaml
@@ -6,7 +6,7 @@ metadata:
   annotations:
     storageclass.kubernetes.io/is-default-class: {{ .Values.storageClass.isDefault }}
 provisioner: rawfile.csi.openebs.io
-reclaimPolicy: Delete
-volumeBindingMode: WaitForFirstConsumer
+reclaimPolicy: {{ .Values.storageClass.reclaimPolicy }}
+volumeBindingMode: {{ .Values.storageClass.volumeBindingMode }}
 allowVolumeExpansion: true
 {{- end }}

--- a/deploy/charts/rawfile-csi/values.yaml
+++ b/deploy/charts/rawfile-csi/values.yaml
@@ -25,6 +25,8 @@ storageClass:
   enabled: false
   name: "csi-rawfile-default"
   isDefault: true
+  reclaimPolicy: Delete
+  volumeBindingMode: WaitForFirstConsumer
 
 imagePullSecrets: []
 serviceMonitor:

--- a/deploy/charts/rawfile-csi/values.yaml
+++ b/deploy/charts/rawfile-csi/values.yaml
@@ -21,6 +21,11 @@ node:
   metrics:
     enabled: false
 
+storageClass:
+  enabled: false
+  name: "csi-rawfile-default"
+  isDefault: true
+
 imagePullSecrets: []
 serviceMonitor:
   enabled: true


### PR DESCRIPTION
Adds to the chart the option to manage a storage class named `csi-rawfile-default`.  

* the name is adjustable with `--set storageClass.name="different-name"`
* the storage class doesn't have to be the default storage class
  * `--set storageClass.isDefault=false`
* One must choose to install this SC
  * `--set storageClass.enabled=true`

other options are settable via:
* `storageClass.reclaimPolicy`
* `storageClass.volumeBindingMode`