### PR TITLE
Update sig-storage containers

### DIFF
--- a/deploy/charts/rawfile-csi/templates/01-controller-plugin.yaml
+++ b/deploy/charts/rawfile-csi/templates/01-controller-plugin.yaml
@@ -64,7 +64,7 @@ spec:
           resources:
             {{- toYaml .Values.controller.resources | nindent 12 }}
         - name: external-resizer
-          image: k8s.gcr.io/sig-storage/csi-resizer:v1.2.0
+          image: k8s.gcr.io/sig-storage/csi-resizer:v1.7.0
           imagePullPolicy: IfNotPresent
           args:
             - "--csi-address=$(ADDRESS)"

--- a/deploy/charts/rawfile-csi/templates/01-node-plugin.yaml
+++ b/deploy/charts/rawfile-csi/templates/01-node-plugin.yaml
@@ -91,7 +91,7 @@ spec:
           resources:
             {{- toYaml .Values.node.resources | nindent 12 }}
         - name: node-driver-registrar
-          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.2.0
+          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.10.0
           imagePullPolicy: IfNotPresent
           args:
             - --csi-address=$(ADDRESS)
@@ -124,7 +124,7 @@ spec:
               cpu: 10m
               memory: 100Mi
         - name: external-provisioner
-          image: k8s.gcr.io/sig-storage/csi-provisioner:v2.2.2
+          image: k8s.gcr.io/sig-storage/csi-provisioner:v3.4.1
           imagePullPolicy: IfNotPresent
           args:
             - "--csi-address=$(ADDRESS)"
@@ -154,7 +154,7 @@ spec:
             - name: socket-dir
               mountPath: /csi
         - name: external-snapshotter
-          image: gcr.io/k8s-staging-sig-storage/csi-snapshotter:v5.0.1
+          image: k8s.gcr.io/sig-storage/csi-snapshotter:v6.2.1
           imagePullPolicy: IfNotPresent
           args:
             - "--csi-address=$(ADDRESS)"


### PR DESCRIPTION
Update the sig-storage containers to something more reasonable for Kubernetes 1.29

this eliminated issues like

```
Failed to watch *v1beta1.CSIStorageCapacity: failed to list *v1beta1.CSIStorageCapacity: the server could not find the requested resource
```


there are new errors like this, but they don't impede creating a PV

```
external-snapshotter W0201 20:40:26.490598       1 reflector.go:424] github.com/kubernetes-csi/external-snapshotter/client/v6/informers/externalversions/f
actory.go:117: failed to list *v1.VolumeSnapshotContent: the server could not find the requested resource (get volumesnapshotcontents.snapshot.storage.k8s
.io)                                                                                                                                                      
external-snapshotter E0201 20:40:26.490628       1 reflector.go:140] github.com/kubernetes-csi/external-snapshotter/client/v6/informers/externalversions/f
actory.go:117: Failed to watch *v1.VolumeSnapshotContent: failed to list *v1.VolumeSnapshotContent: the server could not find the requested resource (get 
volumesnapshotcontents.snapshot.storage.k8s.io)                                                                                                           
```

