### PR TITLE
Fix missing quotes on storage class is default annotation

### DIFF
--- a/deploy/charts/rawfile-csi/Chart.yaml
+++ b/deploy/charts/rawfile-csi/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: rawfile-csi
 description: RawFile Driver Container Storage Interface
 type: application
-version: 0.8.0
-appVersion: 0.8.0
+version: 0.8.1
+appVersion: 0.8.1

--- a/deploy/charts/rawfile-csi/Chart.yaml
+++ b/deploy/charts/rawfile-csi/Chart.yaml
@@ -3,4 +3,4 @@ name: rawfile-csi
 description: RawFile Driver Container Storage Interface
 type: application
 version: 0.8.1
-appVersion: 0.8.1
+appVersion: 0.8.0

--- a/deploy/charts/rawfile-csi/templates/02-storageclass.yaml
+++ b/deploy/charts/rawfile-csi/templates/02-storageclass.yaml
@@ -4,7 +4,7 @@ kind: StorageClass
 metadata:
   name: {{ .Values.storageClass.name }}
   annotations:
-    storageclass.kubernetes.io/is-default-class: {{ .Values.storageClass.isDefault }}
+    storageclass.kubernetes.io/is-default-class: "{{ .Values.storageClass.isDefault }}"
 provisioner: rawfile.csi.openebs.io
 reclaimPolicy: {{ .Values.storageClass.reclaimPolicy }}
 volumeBindingMode: {{ .Values.storageClass.volumeBindingMode }}


### PR DESCRIPTION
Fix missing quotes on storage class is default annotation.
(Seems like I forgot to push this fix while working on the snap and modified the tar archive directly to move forward)