### PR TITLE
actions: Adds TICS nightly job

### DIFF
--- a/.github/workflows/cron-jobs.yaml
+++ b/.github/workflows/cron-jobs.yaml
@@ -1,0 +1,40 @@
+name: Security and quality nightly scan
+
+on:
+  schedule:
+    - cron: '0 10 * * *'
+
+permissions:
+  contents: read
+
+jobs:
+  TICS:
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
+
+      - name: Checking out repo
+        uses: actions/checkout@v4
+
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.22"
+
+      - name: TICS scan
+        run: |
+          export TICSAUTHTOKEN=${{ secrets.TICSAUTHTOKEN }}
+
+          set -x
+
+          # Install the TICS and staticcheck
+          go install honnef.co/go/tools/cmd/staticcheck@v0.5.1
+          . <(curl --silent --show-error 'https://canonical.tiobe.com/tiobeweb/TICS/api/public/v1/fapi/installtics/Script?cfg=default&platform=linux&url=https://canonical.tiobe.com/tiobeweb/TICS/')
+
+          TICSQServer -project  ${{ github.event.repository.name }} -tmpdir /tmp/tics -branchdir "$GITHUB_WORKSPACE"


### PR DESCRIPTION
Project has no unit tests, so they won't be included in the TICS report.