### PR TITLE
Ensure that the rock image can be used as drop-in replacement

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -39,6 +39,7 @@ jobs:
       cache-action: ${{ (github.event_name == 'push') && 'save' || 'restore' }}
       platform-labels: '{"arm64": ["self-hosted-linux-arm64-jammy-large"]}'
       dockerfile-wrapper-b64: ${{ needs.dockerfile-wrapper.outputs.dockerfile-wrapper }}
+      tmate-on-failure: true
 
   run-tests:
     uses: canonical/k8s-workflows/.github/workflows/run_tests.yaml@main

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -10,11 +10,12 @@ jobs:
   dockerfile-wrapper:
     runs-on: ubuntu-latest
     outputs:
-      snap-artifact: ${{ steps.dockerfile-wrapper.outputs.dockerfile-wrapper }}
+      dockerfile-wrapper: ${{ steps.dockerfile-wrapper.outputs.dockerfile-wrapper }}
     steps:
       - name: Get b64 Dockerfile wrapper (Rockcraft workaround)
         id: dockerfile-wrapper
         run: |
+          set -ex
           cat <<EOF > ./dockerfile_wrapper
           ARG IMAGE_TAG
           ARG IMAGE_REPOSITORY
@@ -24,9 +25,8 @@ jobs:
           CMD ["csi-driver"]
           EOF
 
-          b64_dockerfile=$(cat ./dockerfile-wrapper | base64 -w0)
+          b64_dockerfile=$(cat ./dockerfile_wrapper | base64 -w0)
           echo "dockerfile-wrapper=$b64_dockerfile" >> "$GITHUB_OUTPUT"
-
 
   build-and-push-arch-specifics:
     name: Build Rocks and Push Arch Specific Images

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -23,6 +23,7 @@ jobs:
           ENV IMAGE_TAG=\${IMAGE_TAG}
           ENTRYPOINT ["/usr/bin/env", "python3", "/app/rawfile.py"]
           CMD ["csi-driver"]
+          WORKDIR /app
           EOF
 
           b64_dockerfile=$(cat ./dockerfile_wrapper | base64 -w0)

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -40,7 +40,7 @@ jobs:
       arch-skipping-maximize-build-space: '["arm64"]'
       platform-labels: '{"arm64": ["Ubuntu_ARM64_4C_16G_01"]}'
       dockerfile-wrapper-b64: ${{ needs.dockerfile-wrapper.outputs.dockerfile-wrapper }}
-      tmate-on-failure: true
+      tmate-on-failure: false
 
   run-tests:
     uses: canonical/k8s-workflows/.github/workflows/run_tests.yaml@main

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -37,7 +37,8 @@ jobs:
       trivy-image-config: "trivy.yaml"
       multiarch-awareness: true
       cache-action: ${{ (github.event_name == 'push') && 'save' || 'restore' }}
-      platform-labels: '{"arm64": ["self-hosted-linux-arm64-jammy-large"]}'
+      # arch-skipping-maximize-build-space: '["arm64"]'
+      platform-labels: '{"arm64": ["Ubuntu_ARM64_4C_16G_01"]}'
       dockerfile-wrapper-b64: ${{ needs.dockerfile-wrapper.outputs.dockerfile-wrapper }}
       tmate-on-failure: true
 

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -7,9 +7,31 @@ on:
   workflow_dispatch:
 
 jobs:
+  dockerfile-wrapper:
+    runs-on: ubuntu-latest
+    outputs:
+      snap-artifact: ${{ steps.dockerfile-wrapper.outputs.dockerfile-wrapper }}
+    steps:
+      - name: Get b64 Dockerfile wrapper (Rockcraft workaround)
+        id: dockerfile-wrapper
+        run: |
+          cat <<EOF > ./dockerfile_wrapper
+          ARG IMAGE_TAG
+          ARG IMAGE_REPOSITORY
+          ENV IMAGE_REPOSITORY=\${IMAGE_REPOSITORY}
+          ENV IMAGE_TAG=\${IMAGE_TAG}
+          ENTRYPOINT ["/usr/bin/env", "python3", "/app/rawfile.py"]
+          CMD ["csi-driver"]
+          EOF
+
+          b64_dockerfile=$(cat ./dockerfile-wrapper | base64 -w0)
+          echo "dockerfile-wrapper=$b64_dockerfile" >> "$GITHUB_OUTPUT"
+
+
   build-and-push-arch-specifics:
     name: Build Rocks and Push Arch Specific Images
     uses: canonical/k8s-workflows/.github/workflows/build_rocks.yaml@main
+    needs: [dockerfile-wrapper]
     with:
       owner: ${{ github.repository_owner }}
       trivy-image-config: "trivy.yaml"
@@ -17,6 +39,8 @@ jobs:
       cache-action: ${{ (github.event_name == 'push') && 'save' || 'restore' }}
       arch-skipping-maximize-build-space: '["arm64"]'
       platform-labels: '{"arm64": ["Ubuntu_ARM64_4C_16G_01"]}'
+      dockerfile-wrapper-b64: ${{ needs.dockerfile-wrapper.outputs.dockerfile-wrapper }}
+
   run-tests:
     uses: canonical/k8s-workflows/.github/workflows/run_tests.yaml@main
     needs: [build-and-push-arch-specifics]

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -30,7 +30,7 @@ jobs:
 
   build-and-push-arch-specifics:
     name: Build Rocks and Push Arch Specific Images
-    uses: canonical/k8s-workflows/.github/workflows/build_rocks.yaml@main
+    uses: canonical/k8s-workflows/.github/workflows/build_rocks.yaml@lpetrut/b64_dockerfile
     needs: [dockerfile-wrapper]
     with:
       owner: ${{ github.repository_owner }}

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -37,7 +37,7 @@ jobs:
       trivy-image-config: "trivy.yaml"
       multiarch-awareness: true
       cache-action: ${{ (github.event_name == 'push') && 'save' || 'restore' }}
-      arch-skipping-maximize-build-space: '["arm64"]'
+      # arch-skipping-maximize-build-space: '["arm64"]'
       platform-labels: '{"arm64": ["Ubuntu_ARM64_4C_16G_01"]}'
       dockerfile-wrapper-b64: ${{ needs.dockerfile-wrapper.outputs.dockerfile-wrapper }}
 

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -37,7 +37,7 @@ jobs:
       trivy-image-config: "trivy.yaml"
       multiarch-awareness: true
       cache-action: ${{ (github.event_name == 'push') && 'save' || 'restore' }}
-      # arch-skipping-maximize-build-space: '["arm64"]'
+      arch-skipping-maximize-build-space: '["arm64"]'
       platform-labels: '{"arm64": ["Ubuntu_ARM64_4C_16G_01"]}'
       dockerfile-wrapper-b64: ${{ needs.dockerfile-wrapper.outputs.dockerfile-wrapper }}
       tmate-on-failure: true

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -37,8 +37,7 @@ jobs:
       trivy-image-config: "trivy.yaml"
       multiarch-awareness: true
       cache-action: ${{ (github.event_name == 'push') && 'save' || 'restore' }}
-      # arch-skipping-maximize-build-space: '["arm64"]'
-      platform-labels: '{"arm64": ["Ubuntu_ARM64_4C_16G_01"]}'
+      platform-labels: '{"arm64": ["self-hosted-linux-arm64-jammy-large"]}'
       dockerfile-wrapper-b64: ${{ needs.dockerfile-wrapper.outputs.dockerfile-wrapper }}
 
   run-tests:

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -36,7 +36,7 @@ jobs:
       owner: ${{ github.repository_owner }}
       trivy-image-config: "trivy.yaml"
       multiarch-awareness: true
-      cache-action: ${{ (github.event_name == 'push') && 'save' || 'restore' }}
+      cache-action: skip
       arch-skipping-maximize-build-space: '["arm64"]'
       platform-labels: '{"arm64": ["Ubuntu_ARM64_4C_16G_01"]}'
       dockerfile-wrapper-b64: ${{ needs.dockerfile-wrapper.outputs.dockerfile-wrapper }}

--- a/deploy/charts/rawfile-csi/templates/01-controller-plugin.yaml
+++ b/deploy/charts/rawfile-csi/templates/01-controller-plugin.yaml
@@ -60,6 +60,8 @@ spec:
             - name: IMAGE_TAG
               value: "{{ .Values.controller.image.tag }}"
           {{- end }}
+            - name: DATA_DIR_HOST_PATH
+              value: {{ .Values.node.storage.path | quote }}
           volumeMounts:
             - name: socket-dir
               mountPath: /csi

--- a/deploy/charts/rawfile-csi/templates/01-node-plugin.yaml
+++ b/deploy/charts/rawfile-csi/templates/01-node-plugin.yaml
@@ -70,6 +70,8 @@ spec:
             - name: IMAGE_TAG
               value: "{{ .Values.node.image.tag }}"
           {{- end }}
+            - name: DATA_DIR_HOST_PATH
+              value: {{ .Values.node.storage.path | quote }}
             - name: NODE_ID
               valueFrom:
                 fieldRef:

--- a/orchestrator/k8s.py
+++ b/orchestrator/k8s.py
@@ -51,6 +51,7 @@ def run_on_node(fn, node):
         "cmd": json.dumps(fn),
         "image_repository": CONFIG["image_repository"],
         "image_tag": CONFIG["image_tag"],
+        "data_dir_host_path": CONFIG["data_dir_host_path"],
     }
     template = Path("./templates/task.yaml").read_bytes().decode()
     manifest = template.format(**ctx)

--- a/rawfile.py
+++ b/rawfile.py
@@ -16,9 +16,11 @@ from rawfile_util import migrate_all_volume_schemas, gc_all_volumes
 @click.group()
 @click.option("--image-repository", envvar="IMAGE_REPOSITORY")
 @click.option("--image-tag", envvar="IMAGE_TAG")
-def cli(image_repository, image_tag):
+@click.option("--data-dir-host-path", envvar="DATA_DIR_HOST_PATH")
+def cli(image_repository, image_tag, data_dir_host_path):
     CONFIG["image_repository"] = image_repository
     CONFIG["image_tag"] = image_tag
+    CONFIG["data_dir_host_path"] = data_dir_host_path or '/var/csi/rawfile'
 
 
 @cli.command()

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -7,7 +7,7 @@ version: "0.8.2"
 license: Apache-2.0
 
 base: bare
-build-base: ubuntu@24.04
+build-base: ubuntu@22.04
 platforms:
   amd64:
   arm64:
@@ -47,8 +47,6 @@ parts:
       - $CRAFT_STAGE/wheels/wheels.txt
       - ./requirements.txt
     stage-packages:
-      - base-files
-      - libc6
       - e2fsprogs
       - btrfs-progs
       - libbtrfsutil1
@@ -58,10 +56,6 @@ parts:
       - mount
       - coreutils
       - util-linux
-    override-build: |
-      craftctl default
-      mkdir -p $CRAFT_PART_INSTALL/lib64
-      ln -sf /usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2 $CRAFT_PART_INSTALL/lib64/ld-linux-x86-64.so.2
   rawfile:
     after: [rawfile-deps]
     plugin: dump

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -60,7 +60,8 @@ parts:
       - util-linux
     override-build: |
       craftctl default
-      ln -sf /usr/bin/sh "$CRAFT_PART_INSTALL/bin/sh"
+      mkdir -p $CRAFT_PART_INSTALL/lib64
+      ln -sf /usr/lib/x86_64-linux-gnu/ld-linux-x86-64.so.2 $CRAFT_PART_INSTALL/lib64/ld-linux-x86-64.so.2
   rawfile:
     after: [rawfile-deps]
     plugin: dump

--- a/templates/task.yaml
+++ b/templates/task.yaml
@@ -11,7 +11,7 @@ spec:
   volumes:
     - name: data-dir
       hostPath:
-        path: /var/csi/rawfile
+        path: {data_dir_host_path}
         type: DirectoryOrCreate
   nodeSelector: {nodeSelector}
   containers:

--- a/tests/sanity/test_rock.py
+++ b/tests/sanity/test_rock.py
@@ -1,21 +1,30 @@
 #
 # Copyright 2024 Canonical, Ltd.
 #
-import subprocess
+from pathlib import Path
 
 import pytest
+import yaml
 from k8s_test_harness.util import docker_util, env_util
 
 
-@pytest.mark.parametrize("image_version", ["0.8.2"])
+TEST_PATH = Path(__file__)
+REPO_PATH = TEST_PATH.parent.parent.parent
+
+
+def _image_versions():
+    all_rockcrafts = REPO_PATH.glob("**/rockcraft.yaml")
+    yamls = [yaml.safe_load(rock.read_bytes()) for rock in all_rockcrafts]
+    return [rock["version"] for rock in yamls]
+
+
+@pytest.mark.parametrize("image_version", _image_versions())
 def test_sanity(image_version):
     rock = env_util.get_build_meta_info_for_rock_version(
         "rawfile-localpv", image_version, "amd64"
     )
     image = rock.image
-    args = ["python3", "-c", "import app.consts; print(app.consts.PROVISIONER_VERSION)"]
-    try:
-        process = docker_util.run_in_docker(image, args)
-    except subprocess.CalledProcessError as e:
-        assert False, e.stderr or e.stdout
-    assert image_version in process.stdout, process.stderr
+    args = ["pebble", "enter", "-v", "start", "rawfile"]
+    process = docker_util.run_in_docker(image, args, check_exit_code=False)
+    assert process.returncode == 1, "\n".join(process.stderr, process.stdout)
+    assert "Configuration file ~/.kube/config not found" in process.stdout


### PR DESCRIPTION
rawfile-localpv [launches pods on the fly when performing resizes](https://github.com/canonical/rawfile-localpv/blob/main/templates/task.yaml) . This operation currently fails due to the following:

* the image repo and tag env variables aren't specified
  * [the docker file uses build arguments to set these](https://github.com/canonical/rawfile-localpv/blob/3bcdc388a39d9352c1cbe652965c268bcf02d8d3/Dockerfile#L27-L30), however Rockcraft doesn't support templating or build arguments
* the working directory is not set
  * Python imports from /app will fail
  * the pod sets the command explicitly, thus bypassing Pebble. Rocraft doesn't allow setting env variables or the working directory in this case.

As a workaround, we'll use a Dockerfile wrapper to set image fields that Rockcraft would not allow otherwise.

Related PR: https://github.com/canonical/k8s-workflows/pull/39

Fixes: https://github.com/canonical/k8s-snap/issues/1278

Follow-up tasks:

* drop the `--args rawfile` argument that was introduced to accommodate Pebble: https://github.com/canonical/k8s-snap/blob/5eb2f5a059d432e7f970cb799d7be67915cd4869/src/k8s/pkg/k8sd/features/localpv/localpv.go#L38
* update the helm chart from k8s-snap
* since this ensures that the rock image can be used as a drop-in replacement of the upstream image, we'll probably no longer have to maintain this fork
* propose the task.yaml fix upstream