### PR TITLE
fix: change imagePullPolicy to IfNotPresent

### DIFF
--- a/deploy/charts/rawfile-csi/Chart.yaml
+++ b/deploy/charts/rawfile-csi/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: rawfile-csi
 description: RawFile Driver Container Storage Interface
 type: application
-version: 0.9.0
+version: 0.9.1
 appVersion: 0.8.2

--- a/deploy/charts/rawfile-csi/values.yaml
+++ b/deploy/charts/rawfile-csi/values.yaml
@@ -4,7 +4,7 @@ defaults: &defaults
   image:
     repository: ghcr.io/canonical/rawfile-localpv
     tag: 0.8.2
-    pullPolicy: Always
+    pullPolicy: IfNotPresent
   resources:
     limits:
       cpu: 1


### PR DESCRIPTION
Changes `imagePullPolicy` to `IfNotPresent` to fix side-loading deployments.