### PR TITLE
ci: Include FIPS openssl in rockcraft parts

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -24,8 +24,7 @@ jobs:
       arch-skipping-maximize-build-space: '["arm64"]'
       platform-labels: '{"arm64": ["Ubuntu_ARM64_4C_16G_01"]}'
       enabled-ubuntu-pro-features: "fips-updates"
-      multipass-image: "22.04"
-      rockcraft-revisions: '{"amd64": "3494"}'
+      rockcraft-revisions: '{"amd64": "3494", "arm64": "3547"}'
     secrets:
       UBUNTU_PRO_TOKEN: ${{ secrets.UBUNTU_PRO_TOKEN }}
   run-tests:

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -37,6 +37,12 @@ parts:
       for wheel in $CRAFT_STAGE/wheels/*.whl; do
         echo $wheel >> $CRAFT_STAGE/wheels/wheels.txt
       done
+  # NOTE(Hue): Inspired from https://discourse.ubuntu.com/t/build-rocks-with-ubuntu-pro-services/57578
+  openssl:
+    plugin: nil
+    stage-packages:
+      - openssl-fips-module-3 # a Pro only FIPS package for openssl
+      - openssl # now automatically selected from fips-preview
   rawfile-deps:
     after: [btrfsutil]
     plugin: python


### PR DESCRIPTION
### Overview

This PR builds on top of https://github.com/canonical/k8s-workflows/pull/50 and discards multipass as the build environment. Also enables building FIPS-enabled rocks on ARM and only includes OpenSSL from FIPS sources rather than the full core22.