### PR TITLE
Apply security patches

### DIFF
--- a/consts.py
+++ b/consts.py
@@ -1,7 +1,7 @@
 import os
 
 PROVISIONER_NAME = os.getenv("PROVISIONER_NAME", "rawfile.csi.openebs.io")
-PROVISIONER_VERSION = "0.8.2"
+PROVISIONER_VERSION = "0.8.3"
 DATA_DIR = "/data"
 CONFIG = {}
 D_PERMS = 0o700

--- a/deploy/charts/rawfile-csi/Chart.yaml
+++ b/deploy/charts/rawfile-csi/Chart.yaml
@@ -3,4 +3,4 @@ name: rawfile-csi
 description: RawFile Driver Container Storage Interface
 type: application
 version: 0.9.1
-appVersion: 0.8.2
+appVersion: 0.8.3

--- a/deploy/charts/rawfile-csi/values.yaml
+++ b/deploy/charts/rawfile-csi/values.yaml
@@ -3,7 +3,7 @@ provisionerName: "rawfile.csi.openebs.io"
 defaults: &defaults
   image:
     repository: ghcr.io/canonical/rawfile-localpv
-    tag: 0.8.2
+    tag: 0.8.3
     pullPolicy: IfNotPresent
   resources:
     limits:

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,7 +22,7 @@ munch==4.0.0
     # via -r requirements.in
 prometheus-client==0.21.1
     # via -r requirements.in
-protobuf==5.29.3
+protobuf==5.29.5
     # via grpcio-tools
 pykube-ng==23.6.0
     # via -r requirements.in

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -6,6 +6,14 @@ description: Kubernetes LocalPVs on Steroids
 version: "0.8.2"
 license: Apache-2.0
 
+package-repositories:
+  - type: apt
+    formats: [deb-src]
+    components: [main restricted universe multiverse]
+    suites: [jammy-security]
+    key-id: F6ECB3762474EDA9D21B7022871920D1991BC93C
+    url: http://security.ubuntu.com/ubuntu
+
 base: bare
 build-base: ubuntu@22.04
 platforms:

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -10,9 +10,15 @@ package-repositories:
   - type: apt
     formats: [deb-src]
     components: [main restricted universe multiverse]
+    suites: [jammy, jammy-updates]
+    key-id: F6ECB3762474EDA9D21B7022871920D1991BC93C
+    url: https://archive.ubuntu.com/ubuntu
+  - type: apt
+    formats: [deb-src]
+    components: [main restricted universe multiverse]
     suites: [jammy-security]
     key-id: F6ECB3762474EDA9D21B7022871920D1991BC93C
-    url: http://security.ubuntu.com/ubuntu
+    url: https://security.ubuntu.com/ubuntu
 
 base: bare
 build-base: ubuntu@22.04
@@ -71,6 +77,8 @@ parts:
       - coreutils
       - util-linux
     override-stage: |-
+      set -e
+
       apt update
       apt upgrade -y
       craftctl default

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -3,7 +3,7 @@
 name: rawfile-localpv
 summary: RawFilePV
 description: Kubernetes LocalPVs on Steroids
-version: "0.8.2"
+version: "0.8.3"
 license: Apache-2.0
 
 package-repositories:

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -62,6 +62,10 @@ parts:
       - mount
       - coreutils
       - util-linux
+    override-stage: |-
+      apt update
+      apt upgrade -y
+      craftctl default
   rawfile:
     after: [rawfile-deps]
     plugin: dump


### PR DESCRIPTION
- Upgrades the packages manually to apply security patches
- Bumps `protobuf` to `5.29.5` to address `CVE-2025-4565`
- The Go toolchain is updated to `1.23.12` (https://pkg.go.dev/vuln/GO-2025-3849)
- Bumps the `rawfile-localpv` patch version because of the dependency changes