### PR TITLE
fix: disable volume expansion on storage class

### DIFF
--- a/deploy/charts/rawfile-csi/Chart.yaml
+++ b/deploy/charts/rawfile-csi/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: rawfile-csi
 description: RawFile Driver Container Storage Interface
 type: application
-version: 0.9.1
+version: 0.9.2
 appVersion: 0.8.3

--- a/deploy/charts/rawfile-csi/templates/02-storageclass.yaml
+++ b/deploy/charts/rawfile-csi/templates/02-storageclass.yaml
@@ -8,5 +8,5 @@ metadata:
 provisioner: rawfile.csi.openebs.io
 reclaimPolicy: {{ .Values.storageClass.reclaimPolicy }}
 volumeBindingMode: {{ .Values.storageClass.volumeBindingMode }}
-allowVolumeExpansion: true
+allowVolumeExpansion: {{ .Values.storageClass.allowVolumeExpansion }}
 {{- end }}

--- a/deploy/charts/rawfile-csi/values.yaml
+++ b/deploy/charts/rawfile-csi/values.yaml
@@ -38,6 +38,7 @@ storageClass:
   isDefault: true
   reclaimPolicy: Delete
   volumeBindingMode: WaitForFirstConsumer
+  allowVolumeExpansion: false
 
 imagePullSecrets: []
 serviceMonitor:


### PR DESCRIPTION
We currently fail/cause issues during volume expansion due to our usage of rocks(pebble). We should disable this on the storage class until the issues are resolved and volume resizing is supported properly.