### PR TITLE
fix: update trivy to a known-safe version

### DIFF
--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -42,7 +42,7 @@ jobs:
           ref: ${{ matrix.branch }}
           fetch-depth: 0
       - name: Run Trivy vulnerability scanner in repo mode
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           scan-type: "fs"
           ignore-unfixed: true
@@ -109,7 +109,7 @@ jobs:
           echo "head_sha=$SHA" >> "$GITHUB_ENV"
 
       - name: Run Trivy vulnerability scanner in image mode
-        uses: aquasecurity/trivy-action@0.28.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           image-ref: "ghcr.io/${{ github.repository }}:${{ fromJson(steps.read-tag.outputs.result).container_tag }}"
           ignore-unfixed: true


### PR DESCRIPTION
Update trivy to a known safe version following GHSA-69fq-xp46-6x23