### PR TITLE
fix: refactor subprocess calls to use list-form (B602)

### DIFF
--- a/declarative.py
+++ b/declarative.py
@@ -43,11 +43,11 @@ def be_mounted(dev, mountpoint):
 
     fs = current_fs(dev)
     if fs == "ext4":
-        run(f"mount -t ext4 {dev} {mountpoint}")
+        run(["mount", "-t", "ext4", str(dev), str(mountpoint)])
     elif fs == "btrfs":
-        run(f"mount -t btrfs -o flushoncommit {dev} {mountpoint}")
+        run(["mount", "-t", "btrfs", "-o", "flushoncommit", str(dev), str(mountpoint)])
     elif fs == "xfs":
-        run(f"mount -t xfs {dev} {mountpoint}")
+        run(["mount", "-t", "xfs", str(dev), str(mountpoint)])
     else:
         raise Exception(f"Unsupported fs type: {fs}")
 
@@ -55,12 +55,12 @@ def be_mounted(dev, mountpoint):
 def be_unmounted(path):
     path = Path(path)
     while path.is_mount():
-        run(f"umount {path}")
+        run(["umount", str(path)])
 
 
 def current_fs(device):
     res = subprocess.run(
-        f"blkid -o value -s TYPE {device}", shell=True, capture_output=True
+        ["blkid", "-o", "value", "-s", "TYPE", str(device)], capture_output=True
     )
     if res.returncode == 2:  # specified token was not found
         return None
@@ -70,11 +70,13 @@ def current_fs(device):
 def be_formatted(dev, fs):
     def init_fs(device):
         if fs == "ext4":
-            run(f"mkfs.ext4 -m 0 {device}")
+            run(["mkfs.ext4", "-m", "0", str(device)])
         elif fs == "btrfs":
-            run(f"mkfs.btrfs {device}")
+            run(["mkfs.btrfs", str(device)])
             tmp_mnt = tempfile.mkdtemp(prefix="mnt-")
             default_subvol = f"{tmp_mnt}/default"
+            # Multi-step btrfs setup requires a shell script; inputs are
+            # locally-generated tempdir paths, not user-controlled.
             run(
                 f"""
                 set -ex
@@ -87,7 +89,7 @@ def be_formatted(dev, fs):
                 """
             )
         elif fs == "xfs":
-            run(f"mkfs.xfs {device}")
+            run(["mkfs.xfs", str(device)])
         else:
             raise Exception(f"Unsupported fs type: {fs}")
 
@@ -105,10 +107,10 @@ def be_fs_expanded(dev, path):
     fs = current_fs(dev)
     path = Path(path).resolve()
     if fs == "ext4":
-        run(f"resize2fs {dev}")
+        run(["resize2fs", str(dev)])
     elif fs == "btrfs":
-        run(f"btrfs filesystem resize max {path}")
+        run(["btrfs", "filesystem", "resize", "max", str(path)])
     elif fs == "xfs":
-        run(f"xfs_growfs -d {path}")
+        run(["xfs_growfs", "-d", str(path)])
     else:
         raise Exception(f"Unsupported fsType: {fs}")

--- a/fs_util.py
+++ b/fs_util.py
@@ -15,7 +15,7 @@ def path_stats(path):
 
 def device_stats(dev):
     output = subprocess.run(
-        f"blockdev --getsize64 {dev}", shell=True, check=True, capture_output=True
+        ["blockdev", "--getsize64", str(dev)], check=True, capture_output=True
     ).stdout.decode()
     dev_size = int(output)
     return {"dev_size": dev_size}
@@ -24,8 +24,7 @@ def device_stats(dev):
 def dev_to_mountpoint(dev_name):
     try:
         output = subprocess.run(
-            f"findmnt --json --first-only {dev_name}",
-            shell=True,
+            ["findmnt", "--json", "--first-only", str(dev_name)],
             check=True,
             capture_output=True,
         ).stdout.decode()
@@ -37,8 +36,7 @@ def dev_to_mountpoint(dev_name):
 
 def mountpoint_to_dev(mountpoint):
     res = subprocess.run(
-        f"findmnt --json --first-only --nofsroot --mountpoint {mountpoint}",
-        shell=True,
+        ["findmnt", "--json", "--first-only", "--nofsroot", "--mountpoint", str(mountpoint)],
         capture_output=True,
     )
     if res.returncode != 0:

--- a/rawfile_servicer.py
+++ b/rawfile_servicer.py
@@ -128,7 +128,7 @@ class RawFileNodeServicer(csi_pb2_grpc.NodeServicer):
         volume_path = request.volume_path
         size = request.capacity_range.required_bytes
         volume_path = Path(volume_path).resolve()
-        run(f"losetup -c {volume_path}")
+        run(["losetup", "-c", str(volume_path)])
         return csi_pb2.NodeExpandVolumeResponse(capacity_bytes=size)
 
 

--- a/rawfile_util.py
+++ b/rawfile_util.py
@@ -101,11 +101,11 @@ def truncate(img_file, size):
     Set the umask to restrict permissions to the owner only
     """
     with _owner_umask():
-        run(f"truncate -s {size} {img_file}")
+        run(["truncate", "-s", str(size), str(img_file)])
 
 
 def attached_loops(file: str) -> list[str]:
-    out = run_out(f"losetup -j {file}").stdout.decode()
+    out = run_out(["losetup", "-j", str(file)]).stdout.decode()
     lines = out.splitlines()
     devs = [line.split(":", 1)[0] for line in lines]
     return devs
@@ -113,11 +113,11 @@ def attached_loops(file: str) -> list[str]:
 
 def attach_loop(file) -> str:
     def next_loop():
-        loop_file = run_out(f"losetup -f").stdout.decode().strip()
+        loop_file = run_out(["losetup", "-f"]).stdout.decode().strip()
         if not Path(loop_file).exists():
             pfx_len = len("/dev/loop")
             loop_dev_id = loop_file[pfx_len:]
-            run(f"mknod {loop_file} b 7 {loop_dev_id}")
+            run(["mknod", loop_file, "b", "7", loop_dev_id])
         return loop_file
 
     while True:
@@ -125,13 +125,13 @@ def attach_loop(file) -> str:
         if len(devs) > 0:
             return devs[0]
         next_loop()
-        run(f"losetup --direct-io=on -f {file}")
+        run(["losetup", "--direct-io=on", "-f", str(file)])
 
 
 def detach_loops(file) -> None:
     devs = attached_loops(file)
     for dev in devs:
-        run(f"losetup -d {dev}")
+        run(["losetup", "-d", dev])
 
 
 def list_all_volumes():

--- a/remote.py
+++ b/remote.py
@@ -98,11 +98,11 @@ def mount_root_subvol(volume_id):
     img_file = rawfile_util.img_file(volume_id)
     loop_dev = rawfile_util.attach_loop(img_file)
 
-    run(f"mount -t btrfs -o subvolid=0 {loop_dev} {root_subvol}")
+    run(["mount", "-t", "btrfs", "-o", "subvolid=0", str(loop_dev), root_subvol])
     try:
         yield root_subvol
     finally:
-        run(f"umount {root_subvol}")
+        run(["umount", root_subvol])
         pathlib.Path(root_subvol).rmdir()
 
 

--- a/util.py
+++ b/util.py
@@ -36,12 +36,13 @@ def log_grpc_request(func):
 
 
 def run(cmd):
-    return subprocess.run(cmd, shell=True, check=True)
+    if isinstance(cmd, str):
+        return subprocess.run(cmd, shell=True, check=True)
+    return subprocess.run(cmd, check=True)
 
 
-def run_out(cmd: str):
-    p = subprocess.run(cmd, shell=True, capture_output=True)
-    return p
+def run_out(cmd):
+    return subprocess.run(cmd, capture_output=True)
 
 
 class remote_fn(object):


### PR DESCRIPTION
## Summary

Refactor all `subprocess.run(shell=True)` calls to use list-form arguments (`shell=False`), eliminating shell injection risk from f-string interpolation.

This is a proper security fix for bandit B602 findings. The previous PR (#49) only added `# nosec` annotations, which is insufficient — the CSI driver code interpolates volume paths and device names into shell commands via f-strings. If any of these values were attacker-influenced, this would be a shell injection vulnerability.

## Changes

| File | Change |
|------|--------|
| `util.py` | `run()`/`run_out()` now accept lists (`shell=False` by default), with backward-compat string path for one legitimate multi-line shell script |
| `declarative.py` | All single-command `run()` calls converted to lists; btrfs multi-step setup retains `shell=True` (inputs are locally-generated tempdir paths) |
| `fs_util.py` | Direct `subprocess.run()` calls converted to list-form |
| `rawfile_util.py` | All `run()`/`run_out()` callers updated to pass lists |
| `rawfile_servicer.py` | `losetup -c` call converted to list-form |
| `remote.py` | `mount`/`umount` calls converted to list-form |

## Context

Companion to the SAST workflows PR (#48). Replaces #49 (closed — nosec annotations were not justified for this codebase).