### PR TITLE
feat: add s390x and ppc64el build support

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -29,7 +29,7 @@ jobs:
       multiarch-awareness: true
       cache-action: ${{ (github.event_name == 'push') && 'save' || 'restore' }}
       arch-skipping-maximize-build-space: '["arm64"]'
-      platform-labels: '{"arm64": ["self-hosted", "Linux", "ARM64", "jammy"]}'
+      platform-labels: '{"arm64": ["self-hosted", "Linux", "ARM64", "jammy"], "s390x": ["self-hosted-linux-s390x-noble-medium"], "ppc64el": ["self-hosted-linux-ppc64el-noble-edge"]}'
       enabled-ubuntu-pro-features: "fips-updates"
     secrets:
       UBUNTU_PRO_TOKEN: ${{ secrets.UBUNTU_PRO_TOKEN }}

--- a/.rockcraft-version.yaml
+++ b/.rockcraft-version.yaml
@@ -3,3 +3,7 @@ versions:
     channel: latest/edge
   - architecture: arm64
     channel: latest/edge
+  - architecture: ppc64el
+    channel: latest/edge
+  - architecture: s390x
+    channel: latest/edge

--- a/requirements.in
+++ b/requirements.in
@@ -1,5 +1,5 @@
-grpcio-tools
 grpcio
+protobuf
 click
 pyyaml
 pykube-ng

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,10 +11,6 @@ charset-normalizer==3.4.4
 click==8.1.8
     # via -r requirements.in
 grpcio==1.70.0
-    # via
-    #   -r requirements.in
-    #   grpcio-tools
-grpcio-tools==1.70.0
     # via -r requirements.in
 idna==3.10
     # via requests
@@ -23,7 +19,7 @@ munch==4.0.0
 prometheus-client==0.21.1
     # via -r requirements.in
 protobuf==5.29.6
-    # via grpcio-tools
+    # via -r requirements.in
 pykube-ng==23.6.0
     # via -r requirements.in
 pyyaml==6.0.2

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -25,6 +25,8 @@ build-base: ubuntu@22.04
 platforms:
   amd64:
   arm64:
+  ppc64el:
+  s390x:
 
 services:
   rawfile:
@@ -61,8 +63,13 @@ parts:
     after: [btrfsutil]
     plugin: python
     source: .
+    build-packages:
+      - libssl-dev
     build-environment:
       - PIP_NO_CACHE_DIR: "1"
+      # grpcio's bundled BoringSSL does not recognize s390x or ppc64el.
+      # Link against Ubuntu's OpenSSL instead.
+      - GRPC_PYTHON_BUILD_SYSTEM_OPENSSL: "1"
     python-requirements:
       - $CRAFT_STAGE/wheels/wheels.txt
       - ./requirements.txt


### PR DESCRIPTION
Enable a native s390x and ppc64el build for the rawfile-localpv rock by adding the platform to rockcraft.yaml.

grpcio's bundled BoringSSL path does not build cleanly on s390x, so install libssl-dev at build time and set
GRPC_PYTHON_BUILD_SYSTEM_OPENSSL to link grpcio against Ubuntu's OpenSSL instead.

Replace the grpcio-tools dependency with a direct protobuf dependency because code generation is not needed while packing the rock. This avoids building an unnecessary native dependency on s390x.

Assisted-by: Codex 5.5