### PR TITLE
ci: switch rockcraft to latest/edge with force-build

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -12,9 +12,16 @@ on:
         default: false
         type: boolean
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-and-push-arch-specifics:
     name: Build Rocks and Push Arch Specific Images
+    permissions:
+      contents: read
+      packages: write
     uses: canonical/k8s-workflows/.github/workflows/build_rocks.yaml@fix-lxd-guest-pro-attach
     with:
       owner: ${{ github.repository_owner }}
@@ -28,13 +35,16 @@ jobs:
     secrets:
       UBUNTU_PRO_TOKEN: ${{ secrets.UBUNTU_PRO_TOKEN }}
   run-tests:
-    uses: canonical/k8s-workflows/.github/workflows/run_tests.yaml@6b24c265636d618fb98d5f56231c5581a1b429ab # main
+    uses: canonical/k8s-workflows/.github/workflows/run_tests.yaml@main
     needs: [build-and-push-arch-specifics]
     secrets: inherit
     with:
       rock-metas: ${{ needs.build-and-push-arch-specifics.outputs.rock-metas }}
   scan-images:
-    uses: canonical/k8s-workflows/.github/workflows/scan_images.yaml@6b24c265636d618fb98d5f56231c5581a1b429ab # main
+    permissions:
+      security-events: write
+      packages: read
+    uses: canonical/k8s-workflows/.github/workflows/scan_images.yaml@main
     needs: [build-and-push-arch-specifics]
     secrets: inherit
     with:
@@ -43,7 +53,7 @@ jobs:
       trivy-image-config: ./trivy.yaml
   build-and-push-multiarch-manifest:
     name: Combine Rocks and Push Multiarch Manifest
-    uses: canonical/k8s-workflows/.github/workflows/assemble_multiarch_image.yaml@6b24c265636d618fb98d5f56231c5581a1b429ab # main
+    uses: canonical/k8s-workflows/.github/workflows/assemble_multiarch_image.yaml@main
     needs: [build-and-push-arch-specifics]
     if: ${{ needs.build-and-push-arch-specifics.outputs.changed-rock-metas != '[]' }}
     with:

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -22,7 +22,7 @@ jobs:
     permissions:
       contents: read
       packages: write
-    uses: canonical/k8s-workflows/.github/workflows/build_rocks.yaml@fix-lxd-guest-pro-attach
+    uses: canonical/k8s-workflows/.github/workflows/build_rocks.yaml@1f72669125e711d252c472f45ad98f22ff592d28 # main
     with:
       owner: ${{ github.repository_owner }}
       trivy-image-config: "trivy.yaml"
@@ -31,11 +31,10 @@ jobs:
       arch-skipping-maximize-build-space: '["arm64"]'
       platform-labels: '{"arm64": ["self-hosted", "Linux", "ARM64", "jammy"]}'
       enabled-ubuntu-pro-features: "fips-updates"
-      force-build: true
     secrets:
       UBUNTU_PRO_TOKEN: ${{ secrets.UBUNTU_PRO_TOKEN }}
   run-tests:
-    uses: canonical/k8s-workflows/.github/workflows/run_tests.yaml@main
+    uses: canonical/k8s-workflows/.github/workflows/run_tests.yaml@1f72669125e711d252c472f45ad98f22ff592d28 # main
     needs: [build-and-push-arch-specifics]
     secrets: inherit
     with:
@@ -44,7 +43,7 @@ jobs:
     permissions:
       security-events: write
       packages: read
-    uses: canonical/k8s-workflows/.github/workflows/scan_images.yaml@main
+    uses: canonical/k8s-workflows/.github/workflows/scan_images.yaml@1f72669125e711d252c472f45ad98f22ff592d28 # main
     needs: [build-and-push-arch-specifics]
     secrets: inherit
     with:
@@ -53,7 +52,7 @@ jobs:
       trivy-image-config: ./trivy.yaml
   build-and-push-multiarch-manifest:
     name: Combine Rocks and Push Multiarch Manifest
-    uses: canonical/k8s-workflows/.github/workflows/assemble_multiarch_image.yaml@main
+    uses: canonical/k8s-workflows/.github/workflows/assemble_multiarch_image.yaml@1f72669125e711d252c472f45ad98f22ff592d28 # main
     needs: [build-and-push-arch-specifics]
     if: ${{ needs.build-and-push-arch-specifics.outputs.changed-rock-metas != '[]' }}
     with:

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -15,7 +15,7 @@ on:
 jobs:
   build-and-push-arch-specifics:
     name: Build Rocks and Push Arch Specific Images
-    uses: canonical/k8s-workflows/.github/workflows/build_rocks.yaml@6b24c265636d618fb98d5f56231c5581a1b429ab # main
+    uses: canonical/k8s-workflows/.github/workflows/build_rocks.yaml@fix-lxd-guest-pro-attach
     with:
       owner: ${{ github.repository_owner }}
       trivy-image-config: "trivy.yaml"
@@ -24,7 +24,7 @@ jobs:
       arch-skipping-maximize-build-space: '["arm64"]'
       platform-labels: '{"arm64": ["self-hosted", "Linux", "ARM64", "jammy"]}'
       enabled-ubuntu-pro-features: "fips-updates"
-      rockcraft-revisions: '{"amd64": "3494", "arm64": "3547"}'
+      force-build: true
     secrets:
       UBUNTU_PRO_TOKEN: ${{ secrets.UBUNTU_PRO_TOKEN }}
   run-tests:

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -22,7 +22,7 @@ jobs:
     permissions:
       contents: read
       packages: write
-    uses: canonical/k8s-workflows/.github/workflows/build_rocks.yaml@1f72669125e711d252c472f45ad98f22ff592d28 # main
+    uses: canonical/k8s-workflows/.github/workflows/build_rocks.yaml@1f72669125e711d252c472f45ad98f22ff592d28
     with:
       owner: ${{ github.repository_owner }}
       trivy-image-config: "trivy.yaml"
@@ -34,7 +34,7 @@ jobs:
     secrets:
       UBUNTU_PRO_TOKEN: ${{ secrets.UBUNTU_PRO_TOKEN }}
   run-tests:
-    uses: canonical/k8s-workflows/.github/workflows/run_tests.yaml@1f72669125e711d252c472f45ad98f22ff592d28 # main
+    uses: canonical/k8s-workflows/.github/workflows/run_tests.yaml@1f72669125e711d252c472f45ad98f22ff592d28
     needs: [build-and-push-arch-specifics]
     secrets: inherit
     with:
@@ -43,7 +43,7 @@ jobs:
     permissions:
       security-events: write
       packages: read
-    uses: canonical/k8s-workflows/.github/workflows/scan_images.yaml@1f72669125e711d252c472f45ad98f22ff592d28 # main
+    uses: canonical/k8s-workflows/.github/workflows/scan_images.yaml@1f72669125e711d252c472f45ad98f22ff592d28
     needs: [build-and-push-arch-specifics]
     secrets: inherit
     with:
@@ -52,7 +52,7 @@ jobs:
       trivy-image-config: ./trivy.yaml
   build-and-push-multiarch-manifest:
     name: Combine Rocks and Push Multiarch Manifest
-    uses: canonical/k8s-workflows/.github/workflows/assemble_multiarch_image.yaml@1f72669125e711d252c472f45ad98f22ff592d28 # main
+    uses: canonical/k8s-workflows/.github/workflows/assemble_multiarch_image.yaml@1f72669125e711d252c472f45ad98f22ff592d28
     needs: [build-and-push-arch-specifics]
     if: ${{ needs.build-and-push-arch-specifics.outputs.changed-rock-metas != '[]' }}
     with:

--- a/.rockcraft-version.yaml
+++ b/.rockcraft-version.yaml
@@ -1,0 +1,5 @@
+versions:
+  - architecture: amd64
+    channel: latest/edge
+  - architecture: arm64
+    channel: latest/edge


### PR DESCRIPTION
## Summary
- Replace the pinned rockcraft revisions (`rockcraft-revisions: '{"amd64": "3494", "arm64": "3547"}'`) with a root `.rockcraft-version.yaml` selecting the `latest/edge` channel per architecture.
- Add `force-build: true` to the build inputs.
- Point the shared build workflow at `canonical/k8s-workflows/.github/workflows/build_rocks.yaml@fix-lxd-guest-pro-attach`.

## Why
The pinned rockcraft revision was producing FIPS apt-overlay build failures (FIPS-certified packages being downgraded vs. newer noble-archive versions). Moving to `latest/edge` is expected to pick up newer rockcraft handling of the FIPS apt-overlay and resolve this. This mirrors the approach taken in canonical/cilium-rocks#59.

## Notes
- This repo has a single rock at the repository root (`rockcraft.yaml`, version `0.8.3`), so a single `.rockcraft-version.yaml` is placed at the root next to it — the location the shared workflow resolves for the rock.
- `enabled-ubuntu-pro-features: "fips-updates"` is unchanged.
